### PR TITLE
Fixed weird quotes.

### DIFF
--- a/posts/0056_0000.txt
+++ b/posts/0056_0000.txt
@@ -3,7 +3,7 @@
 >>>REQUIRED_MINIMUM:0
 >>>POST:
 
-[quote=Wessolf27;7250903]>Something tells me this less of an alien thing than a cosmic horror/supernatural thing. You can't stay here, but from the looks of how you're so banged up, you might not want to move so much. The best you can do is to not look to the TV, and that's a big problem right now. So maybe... "What would grandma think of in a place like this?“[/quote]
+[quote=Wessolf27;7250903]>Something tells me this less of an alien thing than a cosmic horror/supernatural thing. You can't stay here, but from the looks of how you're so banged up, you might not want to move so much. The best you can do is to not look to the TV, and that's a big problem right now. So maybe... "What would grandma think of in a place like this?"[/quote]
 
 Ha! What would grandma do? Grandma wouldn't have even gotten herself IN this mess. She was a journalist for over forty years, she'd have smelled something this bad miles away and promptly run in the other direction. 
 

--- a/posts/0713_0000.txt
+++ b/posts/0713_0000.txt
@@ -41,7 +41,7 @@
 
 [k]"All right! Jeeze."[/k]
 
-"No! Not like that - wait - watch the hammer! Ok, ok! Careful! I’m-"
+"No! Not like that - wait - watch the hammer! Ok, ok! Careful! I'm-"
 
 [quote=tegerioreo;7788612]Time to get your Snoop on!  Slide through that window like a paid professional.[/quote]
 
@@ -49,7 +49,7 @@
 
 [img]0713_d.png[/img]
 
-"I am inside… hurray..."[/size]
+"I am inside... hurray..."[/size]
 
 
 >>>DISPLAY_PICTURE:0713_b.png

--- a/posts/0716_0000.txt
+++ b/posts/0716_0000.txt
@@ -31,7 +31,7 @@ The smell they noticed on their approach is worse inside. The air is close, damp
 
 [quote=wolftamer9;7790258]Oh yeah, whuzzat?[/quote]
 
-[size=10]"Ah crap, I think I just found Mutt and Jeff’s hazmat suits."
+[size=10]"Ah crap, I think I just found Mutt and Jeff's hazmat suits."
 
 [img]0716_b.png[/img]
 
@@ -51,13 +51,13 @@ The smell they noticed on their approach is worse inside. The air is close, damp
 
 "Apparently."
 
-[k]"Then wouldn’t he have found this Moment thing?"[/k]
+[k]"Then wouldn't he have found this Moment thing?"[/k]
 
-"I don’t know, ok?! I must have hidden it. Previous me. B12."
+"I don't know, ok?! I must have hidden it. Previous me. B12."
 
-[k]"Or it’s not even here."[/k]
+[k]"Or it's not even here."[/k]
 
-"Just - I haven’t even had a chance to look around yet. OK? Gimme a second."
+"Just - I haven't even had a chance to look around yet. OK? Gimme a second."
 
 [k]"You better be quick, otherwise we gotta start [i]running[/i]."[/k][/size]
 

--- a/posts/0719_0000.txt
+++ b/posts/0719_0000.txt
@@ -9,15 +9,15 @@
 
 [quote=Xander;7792187]The unlight might be helpful, yes... But this close to the botfly?[/quote]
 
-"I don’t know if it’s safe so close to the-"
+"I don't know if it's safe so close to the-"
 
 [k]"No! God no."[/k]
 
 "Then what?"
 
-[k]"Look, you’re convinced you left this whatsit here, right? So it [i]should[/i] be somewhere you can find it."[/k]
+[k]"Look, you're convinced you left this whatsit here, right? So it [i]should[/i] be somewhere you can find it."[/k]
 
-"I guess," says Bina. "But I’m not very good at communicating with myself at the best of times."
+"I guess," says Bina. "But I'm not very good at communicating with myself at the best of times."
 
 [k]"Don't think about it that way. Just ask yourself, if you were going to send something important to yourself, where would you put it?"[/k]
 

--- a/posts/0720_0000.txt
+++ b/posts/0720_0000.txt
@@ -9,13 +9,13 @@
 
 Bina hears it too, a thin, quavering, metallic shriek.
 
-"Check the window. You can see the gate through there.”
+"Check the window. You can see the gate through there."
 
 [quote=BlueMoonHound;7792813]>Just get ahold of whatever it is and pull it out. Tell Kendra to check out the noise.[/quote]
 
 [k]"Fine, but you [i]stay down[/i]."[/k]
 
-"Right,”[/size] says Bina, [size=10]“I think... I’ve almost… got it!"[/size]
+"Right,"[/size] says Bina, [size=10]"I think... I've almost... got it!"[/size]
 
 Bina pulls the object from the hole.
 
@@ -31,6 +31,6 @@ There is not enough lego in the whole world for this.
 >>>DISPLAY_PICTURE:0720_a.png
 >>>NOTES:
 
-Dalm, I don’t - I can’t… I mean, what?
+Dalm, I don't - I can't... I mean, what?
 
 

--- a/posts/0722_0000.txt
+++ b/posts/0722_0000.txt
@@ -15,7 +15,7 @@
 
 [img]0722_c.png[/img]
  
-[k]“I know,"[/k][/size] whispers Kendra, [size=10][k]"I thought we killed it too.”[/k][/size]
+[k]"I know,"[/k][/size] whispers Kendra, [size=10][k]"I thought we killed it too."[/k][/size]
 
 
 >>>DISPLAY_PICTURE:0722_b.png

--- a/posts/0723_0000.txt
+++ b/posts/0723_0000.txt
@@ -5,7 +5,7 @@
 
 [size=10]"Is she gone?"
 
-[k]"I wouldn’t count on it,"[/k][/size] says Kendra. [size=10][k]"Did you find the stupid Moment thing yet? Aside from large-dog-and-scary out there we’re about to be drowning in Shakespearian characters."[/k]
+[k]"I wouldn't count on it,"[/k][/size] says Kendra. [size=10][k]"Did you find the stupid Moment thing yet? Aside from large-dog-and-scary out there we're about to be drowning in Shakespearian characters."[/k]
 
 [quote=Lacemaker;7794153]Complain to Kendra about how terribly your other self is treating you.[/quote]
 
@@ -17,13 +17,13 @@
 
 [k]"What does this even mean?"[/k]
 
-"I have no idea!"[/size] says Bina, [size=10]"Maybe it would have made sense to me, if I’d shown up when I was supposed to, but now it’s just nonsense."
+"I have no idea!"[/size] says Bina, [size=10]"Maybe it would have made sense to me, if I'd shown up when I was supposed to, but now it's just nonsense."
 
 [k]"Why even write in code?"[/k]
 
-"Oh, I know that one. It’s so Gregor wouldn’t be able to figure out where the Moment was if he found the note."
+"Oh, I know that one. It's so Gregor wouldn't be able to figure out where the Moment was if he found the note."
 
-[k]"Gregor doesn’t [i]speak French[/i],"[/k][/size] says Kendra. [size=10][k]"This is written [i]in[/i] French. Why not just say exactly where it is?"[/k][/size]
+[k]"Gregor doesn't [i]speak French[/i],"[/k][/size] says Kendra. [size=10][k]"This is written [i]in[/i] French. Why not just say exactly where it is?"[/k][/size]
 
 "Because I am an [i]idiot[/i] apparently!"
 
@@ -35,7 +35,7 @@
 
 [k]"Look, this could mean like a million things."[/k]
 
-"I know…"
+"I know..."
 
 [quote=xooxu;7793227]>Well, start with obvious. Any globes or maps?? Maybe an atlas or something?[/quote]
 
@@ -43,7 +43,7 @@
 
 [k]"Or it... could just be really obvious. Like behind a map of the world, or something."[/k]
 
-"Well I can’t see any [i]maps[/i] in this ominous and faintly unnerving gloom! Can you?"
+"Well I can't see any [i]maps[/i] in this ominous and faintly unnerving gloom! Can you?"
 
 [k]"No, but there were lights on the last time you were here, right? Wouldn't it make sense for her - you - whatever - to pick something that was here before?"[/k][/size]
 

--- a/posts/0724_0000.txt
+++ b/posts/0724_0000.txt
@@ -15,9 +15,9 @@
 
 > Look in the globe.[/quote]
 
-[k]“Bina! What are you doing?”[/k]
+[k]"Bina! What are you doing?"[/k]
 
-[size=10]“Shh! I know where it is!”[/size]
+[size=10]"Shh! I know where it is!"[/size]
 
 
 >>>DISPLAY_PICTURE:0724_a.png

--- a/posts/0725_0000.txt
+++ b/posts/0725_0000.txt
@@ -7,17 +7,17 @@
 
 [quote=badatnamesbluhbluh;7795466]>Crouch, so your head isn't visible through the window.[/quote]
 
-[size=10][k]“Bina, what-”[/k]
+[size=10][k]"Bina, what-"[/k]
 
-“Stay down!”
+"Stay down!"
 
-[k]“Right, good idea, but we don’t even know if it can see.”[/k]
+[k]"Right, good idea, but we don't even know if it can see."[/k]
 
-“Well we don’t know that she [i]can’t[/i] see.”
+"Well we don't know that she [i]can't[/i] see."
 
 [img]0725_a.png[/img]
 
-[k]“All right, all right, I’m crawling. Let’s just get this thing and get out of here.”[/k][/size]
+[k]"All right, all right, I'm crawling. Let's just get this thing and get out of here."[/k][/size]
 
 
 >>>DISPLAY_PICTURE:0725_a.png

--- a/posts/0726_0000.txt
+++ b/posts/0726_0000.txt
@@ -37,7 +37,7 @@ and then dead happens fast and everyone is sad :mspa:[/quote]
 [quote=AweshumeT;7796452]I'm baaaaaack! And finally caught up! Ouo
 If it's any consolation, neato stories like this and a few others have inspired me to begin writing my own in my spare time. All will slowly be posted in the link within my signature. Anyway, keep up the great work and funny Bina faces, Jack! :pranky:[/quote]
 
-Hey! Glad to hear that you’re making your own stuff!
+Hey! Glad to hear that you're making your own stuff!
 
 Bina makes lots of funny faces. It is one of my favorite parts about doing this whole thing. 
 

--- a/posts/0727_0000.txt
+++ b/posts/0727_0000.txt
@@ -7,15 +7,15 @@
 
 It comes apart almost as soon as Bina picks it up.
 
-[k]“Is that it?”[/k]
+[k]"Is that it?"[/k]
 
 [img]0727_a.png[/img]
 
 The watch is small but heavy. 
 
-“I think so.”
+"I think so."
 
-[k]“I was expecting something bigger.”[/k]
+[k]"I was expecting something bigger."[/k]
 
 There is, of course, another note.
 

--- a/posts/0728_0000.txt
+++ b/posts/0728_0000.txt
@@ -5,7 +5,7 @@
 
 [k]"Do you actually know what to-"[/k]
 
-"Nope, but I think I’ve actually given up being mad about that at this point"
+"Nope, but I think I've actually given up being mad about that at this point"
 
 [quote=BreadProduct;7797166]You don't know what to do, do you.
 
@@ -17,25 +17,25 @@
 
 "Yikes."
 
-[k]"So that’s not a watch."[/k]
+[k]"So that's not a watch."[/k]
 
 "No it is not."
 
-[k]"That’s a time machine."[/k]
+[k]"That's a time machine."[/k]
 
 "Yyyup."
 
 [k]"How did she fit all those pieces in there?"[/k]
 
-"I’m going to go with 'magic'."
+"I'm going to go with 'magic'."
 
 [k]"Right, so before you ask, no, I have no idea how it works."[/k]
 
-"Me neither, but I’m guessing it’s going to need some of the green stuff. Here, you take it. Put it on, it’s meant to be worn like a necklace."
+"Me neither, but I'm guessing it's going to need some of the green stuff. Here, you take it. Put it on, it's meant to be worn like a necklace."
 
 [k]"All right but-"[/k]
 
-"And uhh… and gimme your hand."
+"And uhh... and gimme your hand."
 
 "OK, but why?"
 

--- a/posts/0729_0000.txt
+++ b/posts/0729_0000.txt
@@ -11,7 +11,7 @@
 
 Oh god, did she just stutter? OH GOD SHE JUST STUTTERED!
 
-[k]"Soooo - these last few minutes. We haven’t exactly been whispering."[/k]
+[k]"Soooo - these last few minutes. We haven't exactly been whispering."[/k]
 
 "What?"
 

--- a/posts/0730_0000.txt
+++ b/posts/0730_0000.txt
@@ -5,12 +5,12 @@
 
 "Right," says Bina, finding herself calm, composed, her voice steady. "That settles that."
 
-[k]“Bina, we have too-[/k]
+[k]"Bina, we have too-[/k]
 
 [quote=BlueMoonHound;7798181]>WAARRGH! GOGOGOGOGOGOGOGOGOOGO!!!!!!!!
 >GET THE HELL OUT OF THERE!![/quote]
 
-“Hold on!”
+"Hold on!"
 
 No Piotyr. Not this time.
 

--- a/posts/0733_0000.txt
+++ b/posts/0733_0000.txt
@@ -17,15 +17,15 @@ Nah.
 
 DO NOT REVEAL to the viewers who it is.[/quote]
 
-“C’mon you.”
+"C'mon you."
 
 [img]0732_d.png[/img]
 
-“C’mon!”
+"C'mon!"
 
 [img]0732_d.png[/img]
 
-“You better hurry or I’m going to eat all the [i]breakfast![/i]”
+"You better hurry or I'm going to eat all the [i]breakfast![/i]"
 
 [quote=tegerioreo;7799633][s]DO NOT REVEAL to the viewers who it is.[/s][/quote]
 

--- a/posts/0734_0000.txt
+++ b/posts/0734_0000.txt
@@ -3,11 +3,11 @@
 >>>REQUIRED_MINIMUM:0
 >>>POST:
 
-The journals, what we’ve read of them so far, don’t mention Piotyr being here in the other timelines.
+The journals, what we've read of them so far, don't mention Piotyr being here in the other timelines.
 
 [img]0734_a.png[/img]
 
-Most of them don’t mention her at all. 
+Most of them don't mention her at all. 
 
 [img]0734_b.png[/img]
 
@@ -15,7 +15,7 @@ They mention the other one, the Hound, in excessive detail, but not this pale li
 
 [img]0734_c.png[/img]
 
-Kendra is convinced that she’s a ghost.
+Kendra is convinced that she's a ghost.
 
 
 >>>DISPLAY_PICTURE:0734_c.png
@@ -25,7 +25,7 @@ Kendra is convinced that she’s a ghost.
 [img]http://i.imgur.com/ZezlZFe.png[/img]
 [/spoiler][/quote]
 
-Shouldn’t that be dawn of the [i]third[/i] year? :mspa:
+Shouldn't that be dawn of the [i]third[/i] year? :mspa:
 
 [quote=tronn;7799784]Yaay! Two years and going strong, thank you for your wonderful work![/quote]
 
@@ -33,11 +33,11 @@ Thank you so much for reading and commenting so consistently.
 
 [quote=xooxu;7800167]I am confused but pleased by your choice of url, but either way congrats and thank you for 2 years of this stuff.[/quote]
 
-Yeeeah… it’s pretty weird. 
+Yeeeah... it's pretty weird. 
 
-Doing something constantly like this adventure in competitions is often called an ‘iron man’ competition. 
+Doing something constantly like this adventure in competitions is often called an 'iron man' competition. 
 
-Two years is, I think, pretty good! So… Iron Man 2!
+Two years is, I think, pretty good! So... Iron Man 2!
 
 [quote=tegerioreo;7800126]Drat you Jack you have outwitted me yet again!! (villainous mustache twirl)
 Bravo for the two year mark.  Good heavens has it been that long already?[/quote]

--- a/posts/0735_0000.txt
+++ b/posts/0735_0000.txt
@@ -7,19 +7,19 @@ It is 9:37 and thirty six seconds, on the morning of July 16th, 2013.
 
 They've only been here for a few days, but it looks like the other Bina's have wracked up about six years of subjective time in this place.
 
-They’re still getting a handle on all the rules to the Moment. There are a lot of them. Most are pretty esoteric. You wouldn’t notice them until you tried to use a compass, or checked the thermal conductivity of tungsten. 
+They're still getting a handle on all the rules to the Moment. There are a lot of them. Most are pretty esoteric. You wouldn't notice them until you tried to use a compass, or checked the thermal conductivity of tungsten. 
 
 Some though, you notice immediately. The only living things here are those they brought with them. No birds, no bees, no people. 
 
-There’s the three of them, Kendra, Bina, and Piotyr, and the jury is still out on whether Piotyr is actually ‘alive’. 
+There's the three of them, Kendra, Bina, and Piotyr, and the jury is still out on whether Piotyr is actually 'alive'. 
 
 [quote=tegerioreo;7800478]Stare thoughtfully at Piotyr.
 
 Tell Kendra that's ridiculous; ghosts don't eat dog food.[/quote]
 
-Bina personally thinks that the dogs habit of eating anything that isn’t nailed down is a mark in her favour, but Kendra remains unconvinced. 
+Bina personally thinks that the dogs habit of eating anything that isn't nailed down is a mark in her favour, but Kendra remains unconvinced. 
 
-So it's just just Kendra, Bina, maybe Piotyr… and about a hundred million bacteria.
+So it's just just Kendra, Bina, maybe Piotyr... and about a hundred million bacteria.
 
 [quote=xooxu;7800359]> Get a shower, but you have to change your bandages first.[/quote]
 
@@ -27,7 +27,7 @@ So it's just just Kendra, Bina, maybe Piotyr… and about a hundred million bacter
 
 It turns out that a slurry of dirty rainwater, drainage runoff, sugar processing byproducts, decomposed beets, and partially cremated human remains, is really really bad to get in cuts. Who would have guessed?
 
-Despite three days of antibiotic cream and twice-daily showers, Bina’s knees are still puffy, red, and leaking through her bandages.
+Despite three days of antibiotic cream and twice-daily showers, Bina's knees are still puffy, red, and leaking through her bandages.
 
 
 >>>DISPLAY_PICTURE:0735_a.png

--- a/posts/0737_0000.txt
+++ b/posts/0737_0000.txt
@@ -11,7 +11,7 @@ Not exactly forever. Aside from the other problems, they'd starve before to long
 
 [quote=tronn;7801204]>So, where does the water come from? Or food?[/quote]
 
-The water is… complicated.
+The water is... complicated.
 
 The food, in contrast, is pretty simple. What food they have is mostly from the pile of stuff that B12 left them in front of the Laundromat. There's about two weeks of it, mostly canned stuff, but there's fruits and vegetables too in sealed plastic bags.
 

--- a/posts/0738_0000.txt
+++ b/posts/0738_0000.txt
@@ -5,11 +5,11 @@
 
 [quote=obsidalicious;7801637]One of the other houses? How big is this place?[/quote]
 
-There’s this thing that Bina knows about called microtome. Lash explained them to her one day while they were avoiding homework together a few months ago. 
+There's this thing that Bina knows about called microtome. Lash explained them to her one day while they were avoiding homework together a few months ago. 
 
-They’re used in laboratories and they’re basically like super advanced versions of those big paper choppers you’ve probably seen at school. They have these impossibly sharp little blades and they take a sample, a piece of tissue, or an organ, and they cut it into thin little slices, and then mount those slices on slides. 
+They're used in laboratories and they're basically like super advanced versions of those big paper choppers you've probably seen at school. They have these impossibly sharp little blades and they take a sample, a piece of tissue, or an organ, and they cut it into thin little slices, and then mount those slices on slides. 
 
-They’re not a new invention, but the modern ones, the ones that Lash wouldn’t shut up about, can slice tissue so finely that you can see the anatomy of individual cells, just a few microns thick.
+They're not a new invention, but the modern ones, the ones that Lash wouldn't shut up about, can slice tissue so finely that you can see the anatomy of individual cells, just a few microns thick.
 
 The Moment was like that at first. A microtome slide of the entire universe. 
 
@@ -17,21 +17,21 @@ One instant wide.
 
 Or so Kendra tells her.
 
-It’s a lot smaller now.
+It's a lot smaller now.
 
-Bina picks up the note. She’s developing something of an aversion to notes.
+Bina picks up the note. She's developing something of an aversion to notes.
 
-Still, she should probably see what Kendra’s up too. 
+Still, she should probably see what Kendra's up too. 
 
 [img]0738_a.png[/img]
 
-Not a surprise, she was outside all day yesterday trying to figure out why the Viewers aren’t working. 
+Not a surprise, she was outside all day yesterday trying to figure out why the Viewers aren't working. 
 
 [quote=Almonihah;7801750]Well, if you need to eat and drink, one would assume that you can heal. Still, I'm guessing you're more doing research right now than just sitting around waiting to heal.
 
 >What have the journals told you? It seems like the focus should be on the Botfly--it seems to be at the heart of this whole mess, and if you can't figure out how to... well, do something to make it stop making a mess, time might break or something. And that would be bad.[/quote]
 
-They probably do, but Bina hasn’t been reading them.
+They probably do, but Bina hasn't been reading them.
 
 
 >>>DISPLAY_PICTURE:0738_a.png

--- a/posts/0739_0000.txt
+++ b/posts/0739_0000.txt
@@ -5,14 +5,14 @@
 
 [quote=badatnamesbluhbluh;7802433]>How could the other Binas spend [i]years[/i] here, when you barely have supplies for two weeks?[/quote]
 
-Because the Moment appears to expend space to extend time, and the efficiency ratio of that exchange isn’t very good.
+Because the Moment appears to expend space to extend time, and the efficiency ratio of that exchange isn't very good.
 
-After six years, there isn’t much "here" left. 
+After six years, there isn't much "here" left. 
 
 [quote=Beastnix;7802254]>how is that arm, glowy any?[/quote]
 [quote=BlueMoonHound;7802424]I would like to know as well.[/quote]
 
-It’s fine. 
+It's fine. 
 
 Oh it's still glowing if she takes the bandages off, so she just doesn't take the bandages off. 
 
@@ -24,9 +24,9 @@ Really.
 
 It's under control.
 
-[k]“Bina?”[/k] it’s Kendra’s voice from outside. This is followed a split second later by the galumphing clatter of Piotyr’s claws on the hardwood as she barrels toward the front door. [k]“Are you up yet?”[/k]
+[k]"Bina?"[/k] it's Kendra's voice from outside. This is followed a split second later by the galumphing clatter of Piotyr's claws on the hardwood as she barrels toward the front door. [k]"Are you up yet?"[/k]
 
-“Yeah!” says Bina, grabbing her coffee and, after a seconds hesitation, her pills. “Coming!”
+"Yeah!" says Bina, grabbing her coffee and, after a seconds hesitation, her pills. "Coming!"
 
 
 >>>DISPLAY_PICTURE:0739_a.png

--- a/posts/0740_0000.txt
+++ b/posts/0740_0000.txt
@@ -7,13 +7,13 @@
 
 Bina tries, but - 
 
-“Ack, stop trying to trip me you silly dog. I’m letting you out! Yes! I’m letting you out! Just let me - argh.”
+"Ack, stop trying to trip me you silly dog. I'm letting you out! Yes! I'm letting you out! Just let me - argh."
 
 There is a crash and then the thumping sound of tail attempting to wag through the floor. 
 
 [img]0740_a.png[/img]
 
-“There! Door open. See? Go bug Kendra!”
+"There! Door open. See? Go bug Kendra!"
 
 
 >>>DISPLAY_PICTURE:0740_a.png

--- a/posts/0741_0000.txt
+++ b/posts/0741_0000.txt
@@ -13,13 +13,13 @@
 
 [k]"Really?"[/k]
 
-Bina sighs. "No, I’m taking them now."
+Bina sighs. "No, I'm taking them now."
 
 [k]"Hello Piotyr"[/k] says Kendra, catching the tiny dog.
 
 [img]0741_a.png[/img]
 
-[k]"Yes. Yes you are a dog. Yes. Oh my it is exciting isn’t it? Yes it is!"[/k]
+[k]"Yes. Yes you are a dog. Yes. Oh my it is exciting isn't it? Yes it is!"[/k]
 
 Piotyr enthusiastically agrees. It is a day and she is a dog! Hurray!
 
@@ -29,9 +29,9 @@ Piotyr enthusiastically agrees. It is a day and she is a dog! Hurray!
 
 [k]"You have a serious infection. Every little bit helps."[/k]
 
-"And we should be saving this tylenol. We’re almost out."
+"And we should be saving this tylenol. We're almost out."
 
-[k]"Yesterday you could barely [i]walk[/i] by noon, and don’t think I didn’t hear you whimpering every time you stood up."[/k]
+[k]"Yesterday you could barely [i]walk[/i] by noon, and don't think I didn't hear you whimpering every time you stood up."[/k]
 
 "Uuurgh."
 
@@ -39,25 +39,25 @@ Piotyr enthusiastically agrees. It is a day and she is a dog! Hurray!
 
 "Better." 
 
-They’re not.
+They're not.
 
 [k]"No red streaks?"[/k]
 
 "No red streaks."
 
-This, at least, is true. They'd agreed on the first day, when both of them were dealing with their cuts, if either of them ends up with blood poisoning, they’re going to use some of their limited time travel to get to a doctor. 
+This, at least, is true. They'd agreed on the first day, when both of them were dealing with their cuts, if either of them ends up with blood poisoning, they're going to use some of their limited time travel to get to a doctor. 
 
-Neither of them likes that idea, there are a ton of potentially lethal problems with trying it, but dying of septicaemia isn’t something that either of them is willing to put up with. 
+Neither of them likes that idea, there are a ton of potentially lethal problems with trying it, but dying of septicaemia isn't something that either of them is willing to put up with. 
 
-[k]"Wait, did you… just put your pyjamas back on after you had your shower?"[/k]
+[k]"Wait, did you... just put your pyjamas back on after you had your shower?"[/k]
 
 "Nnnnnooooo?"
 
 [k]"Bina! I need you to help me out with this!"[/k]
 
-"I can help, I’ll just -"
+"I can help, I'll just -"
 
-[k]"No no - go change. Finish your coffee. I’ll - I’ll figure something out."[/k]
+[k]"No no - go change. Finish your coffee. I'll - I'll figure something out."[/k]
 
 
 >>>DISPLAY_PICTURE:0741_b.png
@@ -65,16 +65,16 @@ Neither of them likes that idea, there are a ton of potentially lethal problems 
 
 Have you ever wanted to design clothes for Bina? 
 
-Now is your chance! In keeping with the ridiculous schedule for this adventure, anyone who wants to participate has exactly 24 hours from the time this post goes up to post an image (doesn’t have to be a drawing, could be a picture of real clothes) of what you want Bina to wear.
+Now is your chance! In keeping with the ridiculous schedule for this adventure, anyone who wants to participate has exactly 24 hours from the time this post goes up to post an image (doesn't have to be a drawing, could be a picture of real clothes) of what you want Bina to wear.
 
 Things to keep in mind:
 
-- the temperature in the moment is an even 20 degrees celsius (68 fahrenheit), so she doesn’t need a sweater or jacket, but they might be going somewhere colder later
+- the temperature in the moment is an even 20 degrees celsius (68 fahrenheit), so she doesn't need a sweater or jacket, but they might be going somewhere colder later
 - she's going to include the red scarf somewhere in her outfit
-- she’s Bina, use what you know about her
-- she’s not going to wear anything particularly ridiculous, but feel free to suggest ridiculous things if you want too.
+- she's Bina, use what you know about her
+- she's not going to wear anything particularly ridiculous, but feel free to suggest ridiculous things if you want too.
 
-You’re all the best! Thanks!
+You're all the best! Thanks!
 
 [quote=BreadProduct;7803362]Careful with that reference, it's an antique![/quote]
 

--- a/posts/0742_0000.txt
+++ b/posts/0742_0000.txt
@@ -5,9 +5,9 @@
 
 B12 left her some clothes but Bina finds that wearing them feels kinda weird. 
 
-[i]She[/i] wore them, like actually put them on her body, which makes her [i]real[/i] somehow, in a way she hadn’t been before.
+[i]She[/i] wore them, like actually put them on her body, which makes her [i]real[/i] somehow, in a way she hadn't been before.
 
-She must have been so lonely. [i]Her[/i] Kendra died. Her Piotyr was… somewhere else.
+She must have been so lonely. [i]Her[/i] Kendra died. Her Piotyr was... somewhere else.
 
 Of course that does not in any way explain why she had this. 
 
@@ -35,7 +35,7 @@ Well played sir.
 
 [img]costume_designs/BreadProduct_costume.png[/img][/quote]
 
-I like this, I do, but I’m not sure I’m going to be able to use it because all I can see is ninja turtle. 
+I like this, I do, but I'm not sure I'm going to be able to use it because all I can see is ninja turtle. 
 
 This may happen at some point in the future though.
 
@@ -114,12 +114,12 @@ or a pair of tennis shoes with Bina Green accents if you think she would wear th
 
 I never thought of it before but what if Bina's sense of fashion is secretly really wild and she chooses like a big leather coat and trip pants with spiked boots and wristbands[/quote]
 
-This is an excellent collection of cool clothes. I really like those tee’s. Hmm!
+This is an excellent collection of cool clothes. I really like those tee's. Hmm!
 
 [quote=a52;7803967]cmon guys, we all know there's really only one real answer to this:
 [spoiler][img]costume_designs/a52_costume.jpg[/img][/spoiler][/quote]
 
-I dunno, I’m not sure Bina could pull off the suspenders...
+I dunno, I'm not sure Bina could pull off the suspenders...
 
 [quote=tegerioreo;7804151]At 20 degrees C (68F) [b]I[/b] would be wearing a Cardigan.  I don't even switch to short sleeves until the Fahrenheit hits 78.
 
@@ -127,6 +127,6 @@ I suggest cargo pants (practical!  POCKETS!!) and a long sleeved T or a light pu
 
 [quote=a52;7804161]Don't be silly Teg! Mushrooms don't wear clothes![/quote]
 
-Don’t look now Teg, but I think a52 may be on to your CUNNING DISGUISE.
+Don't look now Teg, but I think a52 may be on to your CUNNING DISGUISE.
 
 

--- a/posts/0743_0000.txt
+++ b/posts/0743_0000.txt
@@ -9,7 +9,7 @@ No!
 
 [quote=AlphabetizedInsanity;7804426]> It couldn't hurt to just wear it for a moment, could it?[/quote]
 
-No, no, no, no, no…
+No, no, no, no, no...
 
 [quote=a52;7804431]>Is it your size?[/quote]
 
@@ -35,7 +35,7 @@ She shoves the bizarre fruit thing in the closet and gets dressed.
 
 [img]0743_a.png[/img]
 
-OK! This’ll do.
+OK! This'll do.
 
 
 >>>DISPLAY_PICTURE:0743_a.png
@@ -53,7 +53,7 @@ Now back to figuring out how to animate.[/quote]
 
 Hah! Thank you Alcastar. I like how you drew the clothes on a display manikin. That is neat.
 
-Enjoy animating! (It s funnn…)
+Enjoy animating! (It s funnn...)
 
 [quote=curiousFellow;7804453]I can't really think of an outfit biut I did feel like drawing Bina, or something that resembles her atleast.
 [spoiler][img]http://i1297.photobucket.com/albums/ag34/Thesefellows/Binafanart_zpsogbfhx6j.png[/img][/spoiler][/quote]

--- a/posts/0744_0000.txt
+++ b/posts/0744_0000.txt
@@ -5,7 +5,7 @@
 
 [quote=BlueMoonHound;7804954]>Go do daily life stuff you haven't bothered with in ages.[/quote]
 
-Erggh… she would, she hasn’t eaten breakfast yet, but she’s pretty sure she should check in with Kendra again.
+Erggh... she would, she hasn't eaten breakfast yet, but she's pretty sure she should check in with Kendra again.
 
 [quote=tegerioreo;7805366]Now you're dressed for action, it is time to swing into action!  UP AND AT 'EM!![/quote]
 
@@ -13,21 +13,21 @@ Yeah!
 
 She heads back outside.
 
-“Hey! Uh, did you still need me?”
+"Hey! Uh, did you still need me?"
 
 [img]0744_a.png[/img]
 
-[k]“What?”[/k]
+[k]"What?"[/k]
 
-“Me. Do you -”
+"Me. Do you -"
 
-[k]“Right, wait - hold on.”[/k]
+[k]"Right, wait - hold on."[/k]
 
 Kenda continues to fiddle with the viewer for several seconds. 
 
-“Have you eaten yet? I was thinking I could-”
+"Have you eaten yet? I was thinking I could-"
 
-[k]“Wait, no - I was going make something in a second. Can you - just come hold this light for a second. I can’t hold it and get the right angle.”[/k]
+[k]"Wait, no - I was going make something in a second. Can you - just come hold this light for a second. I can't hold it and get the right angle."[/k]
 
 
 >>>DISPLAY_PICTURE:0744_a.png

--- a/posts/0745_0000.txt
+++ b/posts/0745_0000.txt
@@ -9,7 +9,7 @@ That is...
 
 OK, Bina is not actually sure what that thing is really. It's pretty weird looking, isn't it?
 
-She’s seen Kendra kicking it a few times yesterday, so it doesn’t seem to be working.
+She's seen Kendra kicking it a few times yesterday, so it doesn't seem to be working.
 
 None of this stuff is working.
 

--- a/posts/0746_0000.txt
+++ b/posts/0746_0000.txt
@@ -24,11 +24,11 @@ Kendra inserts a long thin piece of wire with a tiny mirror on the end into a sm
 
 [quote=tegerioreo;7806082]Bina:  Hold the light.  Make small talk.[/quote]
 
-"Soooooo… I'm thinking omelettes?"
+"Soooooo... I'm thinking omelettes?"
 
 There is a loooooooong silence. Kendra wiggles the little mirror on a wand around in the back of the modified TV.
 
-"I mean, for breakfast. I don't just randomly think about egg-based foods. I don't just randomly think about food at all. I mean, not any more then regular people do. Like, sometimes you're like ‘I could really go for a good sandwich' but it's not - I mean, I certainly don't have any weird food-related like, [i]stuff,[/i] or anything."
+"I mean, for breakfast. I don't just randomly think about egg-based foods. I don't just randomly think about food at all. I mean, not any more then regular people do. Like, sometimes you're like 'I could really go for a good sandwich' but it's not - I mean, I certainly don't have any weird food-related like, [i]stuff,[/i] or anything."
 
 "Really."
 
@@ -36,7 +36,7 @@ So this is going well.
 
 [img]0746_a.png[/img]
 
-"I mean, despite whatever you may have seen while looking through the closets earlier. I mean, like, um, I really don't even know why that costume is here and…"
+"I mean, despite whatever you may have seen while looking through the closets earlier. I mean, like, um, I really don't even know why that costume is here and..."
 
 And precisely none of this is getting a response out of Kendra. Bina gives up, and sighs. 
 
@@ -54,7 +54,7 @@ And precisely none of this is getting a response out of Kendra. Bina gives up, a
 
 [k]"Twelve was right. They actually are [i]welded[/i] in there. If I go in through the back with the torch it'll crack, or I'll melt one of the beams or - crap, crap, crap!"[/k]
 
-"Uh…"
+"Uh..."
 
 [k]"Whatever Three was up too when she made these things, she really didn't want anyone to mess with them."[/k]
 

--- a/posts/0747_0000.txt
+++ b/posts/0747_0000.txt
@@ -15,7 +15,7 @@
 
 "Right."
 
-[k]"Hmm… thinking of that. Total entropy remaining. I bet we could figure that out. Find out exactly how much power we've got left before the whole thing comes down. I think, I think yeah, I think Six wrote something about that but never actually did it. The math is funny, it's some kind of hyperplane manifold, but we might be able to -[/k]
+[k]"Hmm... thinking of that. Total entropy remaining. I bet we could figure that out. Find out exactly how much power we've got left before the whole thing comes down. I think, I think yeah, I think Six wrote something about that but never actually did it. The math is funny, it's some kind of hyperplane manifold, but we might be able to -[/k]
 
 "Kendra, I-" Bina breaks into Kendra's enthusiasm, and immediately feels like an asshole doing it.
 

--- a/posts/0748_0000.txt
+++ b/posts/0748_0000.txt
@@ -5,9 +5,9 @@
 
 Eleven was the first one to start taking accurate measurements of the progress of the Nothing. 
 
-Before Nine, it wasn’t possible to get to the boundary without a space shuttle, and for Ten, it would have meant hours of driving every day, but for Eleven, and Twelve it was within walking distance, though Eleven sometimes rode a bike.
+Before Nine, it wasn't possible to get to the boundary without a space shuttle, and for Ten, it would have meant hours of driving every day, but for Eleven, and Twelve it was within walking distance, though Eleven sometimes rode a bike.
 
-Now it’s just down the block.
+Now it's just down the block.
 
 Bina retrieves the relevant equipment from beneath the porch. 
 
@@ -15,13 +15,13 @@ Bina retrieves the relevant equipment from beneath the porch.
 
 That equipment consists of one piece of sidewalk chalk (green), one pencil (hb,mechanical), one journal (moleskine), one leash (dog), and one beagle (possibly undead).
 
-“Come here you!”
+"Come here you!"
 
 Piotyr is a good dog. She knows what leashes mean. Leashes mean walkies! 
 
 [img]0748_b.png[/img]
 
-“Yes, yes, walkies! It’s lots of fun. We’re off to measure the end of the world.”
+"Yes, yes, walkies! It's lots of fun. We're off to measure the end of the world."
 
 
 >>>DISPLAY_PICTURE:0748_b.png

--- a/posts/0749_0000.txt
+++ b/posts/0749_0000.txt
@@ -5,23 +5,23 @@
 
 Bina walks.
 
-It’s nice here. The sun, though she can’t see it, is warm, but the air is crisp and the heat hasn’t built up yet.
+It's nice here. The sun, though she can't see it, is warm, but the air is crisp and the heat hasn't built up yet.
 
-It’s lovely if you don’t think about it too much. Bina imagines that spending too long here would eventually make that crisp morning air feel like a sneeze. Not a regular sneeze, the kind where you [i]know[/i] it’s coming, but it just won’t happen, and you stand there crinkling your nose and wishing you could just [i]sneeze[/i] so you could just get on with your life, but you don’t. 
+It's lovely if you don't think about it too much. Bina imagines that spending too long here would eventually make that crisp morning air feel like a sneeze. Not a regular sneeze, the kind where you [i]know[/i] it's coming, but it just won't happen, and you stand there crinkling your nose and wishing you could just [i]sneeze[/i] so you could just get on with your life, but you don't. 
 
 All that anticipation and no payoff. 
 
 [img]0749_a.png[/img]
 
-None of this seems to bother Piotyr. The little dog seems to be at ease here. She’s gets a bit nervous sometimes, and whines if Bina leaves her alone or goes into a room and closes the door, but if Bina lets her follow her from room to room, Piotyr appears to think everything is ok. 
+None of this seems to bother Piotyr. The little dog seems to be at ease here. She's gets a bit nervous sometimes, and whines if Bina leaves her alone or goes into a room and closes the door, but if Bina lets her follow her from room to room, Piotyr appears to think everything is ok. 
 
-Bina envies her, she doesn’t have to worry about tomorrow, whatever tomorrow even means in a place where nothing really changes.
+Bina envies her, she doesn't have to worry about tomorrow, whatever tomorrow even means in a place where nothing really changes.
 
 Well nothing except [i]the[/i] Nothing, which advances all the time.
 
 [quote=tegerioreo;7808190]Surely you aren't marking the sidewalk and measuring how far the marks have [i]disappeared[/i] since yesterday ... because that would be way too awesome even for you.[/quote]
 
-But that’s [i]exactly[/i] what she’s doing...
+But that's [i]exactly[/i] what she's doing...
 
 [img]0749_b.png[/img]
 
@@ -29,7 +29,7 @@ But that’s [i]exactly[/i] what she’s doing...
 >>>DISPLAY_PICTURE:0749_b.png
 >>>NOTES:
 
-[quote=rachelcp;7807883]jack[spoiler][b]“Wait - Kendra. I’m sorry! I-”[/b] “Go measure the Nothing. I’ll make breakfast.”
+[quote=rachelcp;7807883]jack[spoiler][b]"Wait - Kendra. I'm sorry! I-"[/b] "Go measure the Nothing. I'll make breakfast."
  unless kendra is speaking to herself i think the bold/not bold got mixed up?[/spoiler][/quote]
 
 Merci madame.

--- a/posts/0750_0000.txt
+++ b/posts/0750_0000.txt
@@ -7,15 +7,15 @@
 
 He wished it all back. 
 
-Bina’s pretty sure that won’t work this time.
+Bina's pretty sure that won't work this time.
 
 [img]0750_a.png[/img]
 
-She records everything carefully. Piotyr sniffles about, but doesn’t go near the boundary. 
+She records everything carefully. Piotyr sniffles about, but doesn't go near the boundary. 
 
-There’s a weird feeling here. The silence is immense and there is a sense of growing tension. Like standing next to a powerline. Like the great white wall of Nothing is the skin of a balloon.
+There's a weird feeling here. The silence is immense and there is a sense of growing tension. Like standing next to a powerline. Like the great white wall of Nothing is the skin of a balloon.
 
-Bina can’t decide if it’s holding them in, or holding something else out.
+Bina can't decide if it's holding them in, or holding something else out.
 
 
 >>>DISPLAY_PICTURE:0750_a.png

--- a/posts/0751_0000.txt
+++ b/posts/0751_0000.txt
@@ -5,7 +5,7 @@
 
 [quote=grimalkinInferno;7808626]>Poke it with a stick, I say! The solution to everything is always to poke it with a stick![/quote]
 
-Bina hasn’t actually tried this herself, but she’s heard about what happens if you do it. 
+Bina hasn't actually tried this herself, but she's heard about what happens if you do it. 
 
 She goes and gets a stick.
 
@@ -23,7 +23,7 @@ But when she pulls her hand back...
 
 [img]0751_d.png[/img]
 
-… most of the stick is gone. 
+... most of the stick is gone. 
 
 Things that pass beyond the boundary of the Nothing do not come back.
 

--- a/posts/0752_0000.txt
+++ b/posts/0752_0000.txt
@@ -5,7 +5,7 @@
 
 [quote=K25fF;7809331]Well, that's not concerning at all. Now, step back from the world-devouring boundary.[/quote]
 
-Yeeeeaaaah… probably best to go.
+Yeeeeaaaah... probably best to go.
 
 She finishes recording the measurement before grabbing Piotyr and beating a grateful retreat.
 
@@ -19,9 +19,9 @@ She almost heads straight inside but she stops and decides to check on her secon
 
 [img]0752_b.png[/img]
 
-The watch sits, anchored in the air, ticking. It’s ticks are quiet, but [i]heavy[/i], as though someone very far away were dropping enormous weights.
+The watch sits, anchored in the air, ticking. It's ticks are quiet, but [i]heavy[/i], as though someone very far away were dropping enormous weights.
 
-While you’re inside the Moment, the watch cannot move from this particular spot.
+While you're inside the Moment, the watch cannot move from this particular spot.
 
 That spot is, of course, [i]here[/i].
 


### PR DESCRIPTION
Ran the following bash command in the posts directory:

for i in $( ls -1 ); do
   sed -i -r 's/(\x94|\x93)/"/g;s/\x92/'\''/g;s/\x85/.../g;s/\x91/'\''/g' $i
done

And then manually checked the posts that had been changed to verify that
no unexpected changes had occurred.

This resolved a number of single and double quotes and ellipses that
weren't displaying correctly between posts 713 and 752